### PR TITLE
Spec that demonstrates effect of swapping on order of resolution

### DIFF
--- a/case/backtracking_order.json
+++ b/case/backtracking_order.json
@@ -2,23 +2,35 @@
   "name": "follows backtracking order of operations",
   "index": "backtracking_order",
   "requested": {
-    "cool-gem": "",
-    "weird-gem": ""
+    "a": "",
+    "x": ""
   },
   "base": [],
   "resolved": [
     {
-      "name": "cool-gem",
-      "version": "1.0.1",
-      "dependencies": []
-    },
-    {
-      "name": "weird-gem",
-      "version": "0.2.0",
+      "name": "a",
+      "version": "1.0.0",
       "dependencies": [
         {
-          "name": "cool-gem",
-          "version": "1.0.1",
+          "name": "b",
+          "version": "1.0.0",
+          "dependencies": [
+            {
+              "name": "c",
+              "version": "2.0.0",
+              "dependencies": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "x",
+      "version": "1.1.0",
+      "dependencies": [
+        {
+          "name": "c",
+          "version": "2.0.0",
           "dependencies": []
         }
       ]

--- a/case/backtracking_order.json
+++ b/case/backtracking_order.json
@@ -1,0 +1,28 @@
+{
+  "name": "follows backtracking order of operations",
+  "index": "backtracking_order",
+  "requested": {
+    "cool-gem": "",
+    "weird-gem": ""
+  },
+  "base": [],
+  "resolved": [
+    {
+      "name": "cool-gem",
+      "version": "1.0.1",
+      "dependencies": []
+    },
+    {
+      "name": "weird-gem",
+      "version": "0.2.0",
+      "dependencies": [
+        {
+          "name": "cool-gem",
+          "version": "1.0.1",
+          "dependencies": []
+        }
+      ]
+    }
+  ],
+  "conflicts": []
+}

--- a/index/backtracking_order.json
+++ b/index/backtracking_order.json
@@ -1,36 +1,74 @@
 {
-  "cool-gem": [
+  "a": [
     {
-      "name": "cool-gem",
-      "version": "1.0.1",
-      "dependencies": {}
+      "name": "a",
+      "version": "1.0.0",
+      "dependencies": {
+        "b": ">= 0"
+      }
     },
     {
-      "name": "cool-gem",
+      "name": "a",
       "version": "0.0.1",
-      "dependencies": {}
+      "dependencies": {
+      }
     }
   ],
-  "weird-gem": [
+  "b": [
     {
-      "name": "weird-gem",
-      "version": "0.3.0",
+      "name": "b",
+      "version": "1.0.1",
       "dependencies": {
-        "cool-gem": "<= 1.0.0"
+        "c": "= 1.0.0"
       }
     },
     {
-      "name": "weird-gem",
-      "version": "0.2.0",
+      "name": "b",
+      "version": "1.0.0",
       "dependencies": {
-        "cool-gem": "> 0"
+        "c": ">= 0"
+      }
+    }
+  ],
+  "c": [
+    {
+      "name": "c",
+      "version": "2.0.0",
+      "dependencies": {
       }
     },
     {
-      "name": "weird-gem",
-      "version": "0.1.0",
+      "name": "c",
+      "version": "1.0.0",
       "dependencies": {
-        "cool-gem": "= 0.0.1a"
+      }
+    }
+  ],
+  "x": [
+    {
+      "name": "x",
+      "version": "1.1.0",
+      "dependencies": {
+        "c": "~> 2.0.0"
+      }
+    },
+    {
+      "name": "x",
+      "version": "1.0.0",
+      "dependencies": {
+        "a": "< 1.0"
+      }
+    },
+    {
+      "name": "x",
+      "version": "0.0.2",
+      "dependencies": {
+      }
+    },
+    {
+      "name": "x",
+      "version": "0.0.1",
+      "dependencies": {
       }
     }
   ]

--- a/index/backtracking_order.json
+++ b/index/backtracking_order.json
@@ -1,0 +1,37 @@
+{
+  "cool-gem": [
+    {
+      "name": "cool-gem",
+      "version": "1.0.1",
+      "dependencies": {}
+    },
+    {
+      "name": "cool-gem",
+      "version": "0.0.1",
+      "dependencies": {}
+    }
+  ],
+  "weird-gem": [
+    {
+      "name": "weird-gem",
+      "version": "0.3.0",
+      "dependencies": {
+        "cool-gem": "<= 1.0.0"
+      }
+    },
+    {
+      "name": "weird-gem",
+      "version": "0.2.0",
+      "dependencies": {
+        "cool-gem": "> 0"
+      }
+    },
+    {
+      "name": "weird-gem",
+      "version": "0.1.0",
+      "dependencies": {
+        "cool-gem": "= 0.0.1a"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Swapping can, in certain cases, affect the order in which dependencies are considered and thus potentially the resolution that is first reached. This spec resolves differently when swapping is active versus when it is removed.

There are two possible resolutions that could be reached for this gemset, `[cool-gem-1.0.1 weird-gem-0.2.0]` or `[cool-gem-0.0.1 weird-gem-0.3.0]`. Since `cool-gem` is listed first by `sort_dependencies`, the backtracking algorithm should end with a stack like this:

cool-gem-1.0.1
~~weird-gem-0.3.0~~
weird-gem-0.2.0

But with swapping, the stack gets modified:

~~cool-gem-1.0.1~~ cool-gem-0.0.1 (swapped)
weird-gem-0.3.0 ⮵

I guess the question is if it's important that the resolution algorithm have predictable backtracking behavior based on the order of the dependencies. Swapping will still always reach a valid resolution, but it takes the dependency sort as more of a friendly suggestion than a rule 🙂

For more context: I discovered this through a project I'm working on that sorts the dependencies in an unusual order and expects the results to be dependent on that order. So while the above example is one symptom of this, it's more likely to arise for anything using the Molinillo resolver with a non-standard sort order.