### PR TITLE
Add pre-release version selection spec

### DIFF
--- a/case/prerelease_version.json
+++ b/case/prerelease_version.json
@@ -1,0 +1,29 @@
+{
+  "name": "selects a prerelease version when specified",
+  "index": "prerelease_version",
+  "requested": {
+    "a": "= 2.0.0.beta1",
+    "b": ""
+  },
+  "base": [],
+  "resolved": [
+    {
+      "name": "b",
+      "version": "1.0.0",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "2.0.0.beta1",
+          "dependencies": [
+            {
+              "name": "c",
+              "version": "1.0.0",
+              "dependencies": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "conflicts": []
+}

--- a/index/prerelease_version.json
+++ b/index/prerelease_version.json
@@ -1,0 +1,32 @@
+{
+  "a": [
+    {
+      "name": "a",
+      "version": "1.0.0",
+      "dependencies": {}
+    },
+    {
+      "name": "a",
+      "version": "2.0.0.beta1",
+      "dependencies": {
+        "c": ">= 1.0.0"
+      }
+    }
+  ],
+  "b": [
+    {
+      "name": "b",
+      "version": "1.0.0",
+      "dependencies": {
+        "a": ">= 1.0.0"
+      }
+    }
+  ],
+  "c": [
+    {
+      "name": "c",
+      "version": "1.0.0",
+      "dependencies": {}
+    }
+  ]
+}


### PR DESCRIPTION
This was failing on https://github.com/CocoaPods/Molinillo/pull/69 before https://github.com/CocoaPods/Molinillo/pull/69/commits/022015e0b24ed060e68f702ff6a0e47704545b90, and is a non-obvious failure case. Worth having this spec for it if https://github.com/CocoaPods/Molinillo/pull/69 is merged.