### PR TITLE
Spec circular dependencies that only appear for one bad version

### DIFF
--- a/case/circular.json
+++ b/case/circular.json
@@ -1,5 +1,5 @@
 {
-  "name": "detects circular depedencies",
+  "name": "detects circular dependencies",
   "index": "circular",
   "requested": {
     "circular_app": ""

--- a/case/fixed_circular.json
+++ b/case/fixed_circular.json
@@ -1,0 +1,33 @@
+{
+  "name": "handle circular dependencies that only appear for one bad version",
+  "index": "fixed_circular",
+  "requested": {
+    "circular_app": ""
+  },
+  "base": [],
+  "resolved": [
+    {
+      "name": "circular_app",
+      "version": "1.0.0",
+      "dependencies": [
+        {
+          "name": "foo",
+          "version": "0.2.6",
+          "dependencies": [
+            {
+              "name": "bar",
+              "version": "0.1.0",
+              "dependencies": []
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "version": "0.1.0",
+          "dependencies": []
+        }
+      ]
+    }
+  ],
+  "conflicts": []
+}

--- a/index/fixed_circular.json
+++ b/index/fixed_circular.json
@@ -30,6 +30,11 @@
         "foo": ">= 0",
         "bar": ">= 0"
       }
+    },
+    {
+      "name": "circular_app",
+      "version": "0.0.1",
+      "dependencies": []
     }
   ]
 }

--- a/index/fixed_circular.json
+++ b/index/fixed_circular.json
@@ -1,0 +1,35 @@
+{
+  "foo": [
+    {
+      "name": "foo",
+      "version": "0.2.6",
+      "dependencies": {
+        "bar": ">= 0"
+      }
+    }
+  ],
+  "bar": [
+    {
+      "name": "bar",
+      "version": "1.0.0",
+      "dependencies": {
+        "foo": ">= 0.1"
+      }
+    },
+    {
+      "name": "bar",
+      "version": "0.1.0",
+      "dependencies": {}
+    }
+  ],
+  "circular_app": [
+    {
+      "name": "circular_app",
+      "version": "1.0.0",
+      "dependencies": {
+        "foo": ">= 0",
+        "bar": ">= 0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Spec for part of the behaviour in https://github.com/CocoaPods/Molinillo/pull/73.