### PR TITLE
Spec that any grouping logic insists groups are contiguous

### DIFF
--- a/case/contiguous_grouping.json
+++ b/case/contiguous_grouping.json
@@ -1,0 +1,29 @@
+{
+  "name": "picks the latest version when non-contiguous grouping would fail",
+  "index": "contiguous_grouping",
+  "requested": {
+    "a": "",
+    "b": ""
+  },
+  "base": [],
+  "resolved": [
+    {
+      "name": "b",
+      "version": "1.0.0",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1.0.1",
+          "dependencies": [
+            {
+              "name": "c",
+              "version": "1.0.0",
+              "dependencies": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "conflicts": []
+}

--- a/index/contiguous_grouping.json
+++ b/index/contiguous_grouping.json
@@ -1,0 +1,37 @@
+{
+  "a": [
+    {
+      "name": "a",
+      "version": "1.0.0",
+      "dependencies": {}
+    },
+    {
+      "name": "a",
+      "version": "1.0.1",
+      "dependencies": {
+        "c": ""
+      }
+    },
+    {
+      "name": "a",
+      "version": "1.0.2",
+      "dependencies": {}
+    }
+  ],
+  "b": [
+    {
+      "name": "b",
+      "version": "1.0.0",
+      "dependencies": {
+        "a": "!= 1.0.2"
+      }
+    }
+  ],
+  "c": [
+    {
+      "name": "c",
+      "version": "1.0.0",
+      "dependencies": {}
+    }
+  ]
+}


### PR DESCRIPTION
Test for https://github.com/CocoaPods/Molinillo/pull/83. Fails on master.